### PR TITLE
Add upgradeable dnscrypt resolver file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,10 @@ Below the line
 
 *Append a local-address line to use dnscrypt on a port other than 53, like 5355.*
 
+By default, the `resolvers-list` will point to the dnscrypt version specific resolvers file. When dnscrypt is updated, this version may no longer exist, and if it does, may point to an outdated file. This can be fixed by changing the resolvers file in `/Library/LaunchDaemons/homebrew.mxcl.dnscrypt-proxy.plist` to the symlinked version in `/usr/local/share`:
+
+    <string>--resolvers-list=/usr/local/share/dnscrypt-proxy/dnscrypt-resolvers.csv</string>
+
 Finally, start the program
 
     sudo launchctl load /Library/LaunchDaemons/homebrew.mxcl.dnscrypt-proxy.plist


### PR DESCRIPTION
After upgrading dnscrypt, it would no longer start since the version specific resolver file was no longer available (`<string>--resolvers-list=/usr/local/Cellar/dnscrypt-proxy/1.6.0_3/share/dnscrypt-proxy/dnscrypt-resolvers.csv</string>`).

Updating the plist documentation to refer to the symlinked `dnscrypt-resolvers.csv` file, which should always be available.

Fixes #77 