### PR TITLE
Add network/auth event monitoring app: Security Growler

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Finally, you may wish to disable feature, *Automatically allow signed software t
 > If you run an unsigned app that is not listed in the firewall list, a dialog appears with options to Allow or Deny connections for the app. If you choose Allow, OS X signs the application and automatically adds it to the firewall list. If you choose Deny, OS X adds it to the list but denies incoming connections intended for this app.
 
 #### Third party firewalls
-Programs such as [Little Snitch](https://www.obdev.at/products/littlesnitch/index.html), [Hands Off](https://www.oneperiodic.com/products/handsoff/) and [Radio Silence](http://radiosilenceapp.com/) provide a good balance of usability and security.
+Programs such as [Little Snitch](https://www.obdev.at/products/littlesnitch/index.html), [Hands Off](https://www.oneperiodic.com/products/handsoff/), [Radio Silence](http://radiosilenceapp.com/) and [Security Growler](https://pirate.github.io/security-growler/) provide a good balance of usability and security.
 
 <img width="349" alt="Example of Little Snitch monitored session" src="https://cloud.githubusercontent.com/assets/12475110/10596588/c0eed3c0-76b3-11e5-95b8-9ce7d51b3d82.png">
 


### PR DESCRIPTION
Disclaimer: I'm the author of https://github.com/pirate/security-growler

It's a logfile and sockets monitor that alerts you to security events like `sudo` being used, TCP connections being opened, VNC users connecting, etc.

Maybe it belongs in a different section?  Since it's not exactly a firewall, just a monitor...