### PR TITLE
Homebrew Google analytics opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,11 @@ Alternatively, you could download, compile and install software directly from th
 
 Remember to periodically run `brew update` and `brew upgrade` on trusted, secure networks to install software updates.
 
+According to [Homebrew/brew/blob/master/share/doc/homebrew/Analytics.md](https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Analytics.md), Homebrew will start logging user behaviour trough Google Analytics. 
+
+The documentation says the user can opt-out by including an environment variable `HOMEBREW_NO_ANALYTICS=1`. 
+Include that on your `.bashrc`or `.zshrc`.
+
 ## DNS
 
 #### Hosts file


### PR DESCRIPTION
According to https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Analytics.md, Homebrew will start logging user behaviour trough Google Analytics. 

The documentation says the user can opt-out by including an environment variable. `HOMEBREW_NO_ANALYTICS=1`

Before approval, please check if you agree that the `.bashrc` or `.zshrc` are the best place to include that, of if other place should be used, like `/etc/profile`.

Thanks!